### PR TITLE
Fixes from almaif work

### DIFF
--- a/tce/src/applibs/LLVMBackend/TDGen.cc
+++ b/tce/src/applibs/LLVMBackend/TDGen.cc
@@ -3374,6 +3374,9 @@ TDGen::writeInstrInfo(std::ostream& os) {
         }
         opNames_["ST32fr"] = "ST32";
         opNames_["ST32fi"] = "ST32";
+
+        opNames_["ST32hr"] = "ST32";
+        opNames_["ST32hi"] = "ST32";
         
         opNames_["ST16hr"] = "ST16";
         opNames_["ST16hi"] = "ST16";

--- a/tce/src/bintools/Compiler/tcecc.in
+++ b/tce/src/bintools/Compiler/tcecc.in
@@ -710,7 +710,7 @@ def optimizeBytecode(inFile, fileNamePrefix, extraSwitches = ""):
         optSwitches += ' -' + ' -'.join(extra_opts)
 
     internalize_api_list = " -internalize-public-api-list=" \
-                           "_start,_pthread_start,_dthread_start,memcpy"
+                           "_start,_pthread_start,_dthread_start,memcpy,memset"
     if options.keep_symbols != "":
         internalize_api_list += "," + options.keep_symbols
 
@@ -764,7 +764,7 @@ def linkEmulationFuncs(inFile, fileNamePrefix):
     outputName = fileNamePrefix + "_emul_internalized.bc"
 
     internalize_api_list = " -internalize-public-api-list=" \
-                           "_start,_pthread_start,memcpy"
+                           "_start,_pthread_start,memcpy,memset"
     if options.keep_symbols != "":
         internalize_api_list += "," + options.keep_symbols
 

--- a/tce/src/procgen/ProDe/OpsetDialog.cc
+++ b/tce/src/procgen/ProDe/OpsetDialog.cc
@@ -30,24 +30,28 @@
  * @note rating: red
  */
 
-#include <algorithm>
-#include <string>
+#include "OpsetDialog.hh"
 
 #include <wx/spinctrl.h>
 #include <wx/statline.h>
 #include <wx/textctrl.h>
-#include "OpsetDialog.hh"
-#include "HWOperation.hh"
-#include "Operation.hh"
-#include "FunctionUnit.hh"
-#include "OperationPool.hh"
-#include "OperationModule.hh"
-#include "OperationIndex.hh"
-#include "WxConversion.hh"
+
+#include <algorithm>
+#include <string>
+
+#include "AddressSpace.hh"
 #include "ErrorDialog.hh"
-#include "FUPort.hh"
 #include "ExecutionPipeline.hh"
+#include "FUPort.hh"
+#include "FunctionUnit.hh"
+#include "HWOperation.hh"
+#include "MathTools.hh"
 #include "Operand.hh"
+#include "Operation.hh"
+#include "OperationIndex.hh"
+#include "OperationModule.hh"
+#include "OperationPool.hh"
+#include "WxConversion.hh"
 
 using namespace TTAMachine;
 
@@ -237,7 +241,14 @@ OpsetDialog::createOperation(FunctionUnit& fu) {
         opWidths.Append(WxConversion::toWxString(oper.width()));
 
         if (oper.isInput()) {
-            inputs[oper.width()].insert(oper.index());
+            int opWidth;
+            if (oper.isAddress()) {
+                assert(fu.hasAddressSpace());
+                opWidth = MathTools::requiredBits(fu.addressSpace()->end());
+            } else {
+                opWidth = oper.width();
+            }
+            inputs[opWidth].insert(oper.index());
             opWidths.Append(WxConversion::toWxString("b input, "));
             operation->pipeline()->addPortRead(oper.index(), 0, 1);
         } else if (oper.isOutput()) {


### PR DESCRIPTION
Three unrelated commits fixing some bugs I found:
First one was found when compiling some fp16 code for LE machines.

The second one was a ProDe GUI bug that prevented any addition of memory ops to 32-bit LE machines. This was due to the base.opp now defining the LE memory operations trigger operand width to be 64. (Due to le-64 support)

The third one was found when compiling printf for PoCL use case. Here compiler would optimize away the memset function, and then LLVM would add memset intrinsics anyway.

