### PR TITLE
Fix warnings that cause tce-selftest to fail under clang

### DIFF
--- a/tce/scripts/tce-selftest
+++ b/tce/scripts/tce-selftest
@@ -875,6 +875,6 @@ dot_product (global const float4 *a,
 
 
 if __name__ == '__main__':
-    print("Testing TCE installation, this can take up to two hours.")
-    print("Time to go for a lunch? Use -v to see the progress.")
+    print("Testing TCE installation, this can take up to 15 minutes.")
+    print("Time to go for a coffee? Use -v to see the progress.")
     unittest.main()

--- a/tce/src/applibs/LLVMBackend/plugin/TCEISelLowering.cc
+++ b/tce/src/applibs/LLVMBackend/plugin/TCEISelLowering.cc
@@ -1109,6 +1109,7 @@ TCETargetLowering::LowerBuildVector(SDValue Op, SelectionDAG &DAG) const {
                 case MVT::i8: packName << "8"; break;
                 case MVT::i16: packName << "16"; break;
                 case MVT::i32: packName << "32"; break;
+                default: std::cerr << elemVT.SimpleTy << ", "; break;
                 }
                 packName << "X" << elemCount;
                 // pack op not found from the adf or too big

--- a/tce/src/applibs/LLVMBackend/plugin/TCESubtarget.cc
+++ b/tce/src/applibs/LLVMBackend/plugin/TCESubtarget.cc
@@ -74,7 +74,6 @@ TCESubtarget::TCESubtarget(TCETargetMachinePlugin* plugin)
       pluginFile_(BackendPluginFile),
       plugin_(plugin),
       InstrItins(getInstrItineraryForCPU("generic")) {
-    assert(&InstrItins != nullptr && "IstrItins nullptr");
     assert(InstrItins.Itineraries != nullptr && "IstrItins not initialized");
 }
 


### PR DESCRIPTION
clang was generating two compile warnings to stderr, causing the self-test to fail. 

Fixes:
1. Removed an assertion that would never fail
2. Added a default clause to a switch statement that only needed three cases out of 91.
Fixes #185 