### PR TITLE
Fix "'log2' is not a member of 'std'"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,4 @@ scripts/tce-selftest
 /openasip/hdb/generate_lsu/*
 !/openasip/hdb/generate_lsu/shared
 !/openasip/hdb/generate_lsu/generate.py
+openasip/scripts/tce-selftest

--- a/openasip/src/applibs/ProGe/RV32MicroCodeGenerator.cc
+++ b/openasip/src/applibs/ProGe/RV32MicroCodeGenerator.cc
@@ -25,6 +25,7 @@
  * @note rating: red
  */
 
+#include <cmath>
 #include <vector>
 #include <string>
 #include <memory>


### PR DESCRIPTION
Fixes #191 