### PR TITLE
Ignore clangd working files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 openasip/**/Makefile
 /openasip/hdb/generate_lsu_*.hdb
 /openasip/hdb/generate_lsu/*
+compile_commands.json
 compiletest.*.log
 core
 core.*

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.pypp.cpp
 *.pypp.hpp
 *.so
+**/.cache/clangd
 **/.deps
 **/.libs
 **/*-runner

--- a/.gitignore
+++ b/.gitignore
@@ -143,9 +143,8 @@ openasip/test/Makefile.in
 scripts/tce-selftest
 src/bintools/Compiler/tcecc
 testsuite/**/data
-testsuite/systemtest_long/bintools/Compiler/**/program.bc
-testsuite/systemtest_long/bintools/Scheduler/**/program.bc
-testsuite/systemtest/bintools/Scheduler/**/program.bc
+testsuite/**/proge-output
+testsuite/systemtest_long/**/program.bc
 vgcore*
 
 # Keep these files (not generated, so we need them in the repo)


### PR DESCRIPTION
A little help for clang and clangd users. clangd indexes all of the files in the project and the index files are stored here (.cache/clangd/). 
