### PR TITLE
Prode: fix operand usage dialog box for dark mode

### DIFF
--- a/openasip/CHANGES
+++ b/openasip/CHANGES
@@ -1,3 +1,14 @@
+2.1     unreleased
+=====================
+
+Notable changes and features
+----------------------------
+
+Notable bugfixes
+----------------------------
+- ProDe: Fix operand usage and resource boxes to use default colors propagated
+  from system theme instead of manually setting them to black and white.
+
 2.0     November 2022
 =====================
 

--- a/openasip/src/procgen/ProDe/OperationDialog.cc
+++ b/openasip/src/procgen/ProDe/OperationDialog.cc
@@ -146,10 +146,6 @@ OperationDialog::initialize() {
     // Resource grid.
     resourceGrid_->EnableEditing(false);
     resourceGrid_->SetDefaultCellAlignment(wxALIGN_CENTRE, wxALIGN_CENTRE);
-    resourceGrid_->SetDefaultCellBackgroundColour(
-        wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
-    resourceGrid_->SetSelectionBackground(ProDeConstants::WHITE_COLOR);
-    resourceGrid_->SetSelectionForeground(ProDeConstants::BLACK_COLOR);
     resourceGrid_->DisableDragColSize();
     resourceGrid_->DisableDragRowSize();
 
@@ -157,7 +153,6 @@ OperationDialog::initialize() {
     usageGrid_->EnableEditing(false);
     usageGrid_->DisableDragColSize();
     usageGrid_->DisableDragRowSize();
-    usageGrid_->SetDefaultCellBackgroundColour(ProDeConstants::WHITE_COLOR);
 
     latencyText_ = dynamic_cast<wxStaticText*>(FindWindow(ID_LATENCY));
 }


### PR DESCRIPTION
In Ubuntu 20's dark mode the FU's operand usage dialog (the one with R's and W's) was white-on-white.
This change makes it so in light-mode it's
black-on-white, and in dark-mode white-on-grey.

Maybe somebody else should test this on different system? I tested it with ubuntu 20.04 Gnome's light and dark mode