### PR TITLE
Buildopset: fix buildopset linking to libopenasip

### DIFF
--- a/openasip/src/base/osal/OperationBuilder.cc
+++ b/openasip/src/base/osal/OperationBuilder.cc
@@ -176,7 +176,7 @@ OperationBuilder::buildObject(
                it can happen the loading of libopenasip.so to access some 
                specific functionality might not import all the symbols
                required by the .opb loaded by libopenasip later. */
-            CXXFLAGS += " -L" + Application::installationDir() + "/lib -lopenasip ";
+            LDFLAGS += " -L" + Application::installationDir() + "/lib -lopenasip ";
         }
 
         // Add user defined CXXFLAGS + CPPFLAGS to the end because they


### PR DESCRIPTION
The library ordering of the command was wrong which lead to it not creating a dependency to libopenasip.so.

This was causing problems with missing openasip symbols when pocl's ttasim driver was dlopening custom operation opb.