### PR TITLE
Improve column renaming for HDB migration 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,29 +92,22 @@ Ubuntu 20.04+ / Debian 11
 &nbsp; tcl8.6-dev libedit-dev libsqlite3-dev sqlite3 libxerces-c-dev g++ make \ <br>
 &nbsp; latex2html libffi-dev autoconf automake libtool subversion git cmake graphviz_
 
-Ubuntu 16.04 LTS / 18.04 LTS
-----------------------------
-
-&nbsp; _sudo apt-get install libwxgtk3.0-dev libboost-all-dev \ <br>
-&nbsp; tcl8.6-dev libedit-dev libsqlite3-dev sqlite3 libxerces-c-dev g++ make \ <br>
-&nbsp; latex2html libffi-dev autoconf automake libtool subversion git cmake_
-
-Ubuntu 14.04 LTS and older
+Ubuntu 18.04 LTS and older
 --------------------------
 
-Not supported anymore due to GCC version too low (LLVM currently requires 5.1+)
+Not supported anymore due to SQLite version too low (currently requires 3.25+)
 
-Debian 9 / 10
--------------
+Debian 10
+---------
 
 &nbsp; _sudo apt-get install libwxgtk3.0-dev libboost-{filesystem,graph,regex,thread}-dev \ <br>
 &nbsp; tcl8.6-dev libedit-dev libsqlite3-dev sqlite3 libxerces-c-dev g++ make latex2html \ <br>
 &nbsp; libffi-dev autoconf automake libtool subversion git cmake_
 
-Debian 8 and older
+Debian 9 and older
 ------------------
 
-Not supported anymore due to GCC version too low (LLVM currently requires 5.1+)
+Not supported anymore due to SQLite version too low (currently requires 3.25+)
 
 Red Hat Enterprise Linux 8 & clones
 -----------------------------------

--- a/openasip/CHANGES
+++ b/openasip/CHANGES
@@ -3,13 +3,13 @@
 
 Notable changes and features
 ----------------------------
+- SQLite version requirement raised to 3.25+
 
 Notable bugfixes
 ----------------------------
 - ProDe: Fix operand usage and resource boxes to use default colors propagated
   from system theme instead of manually setting them to black and white.
 
->>>>>>> origin/prode-operand-dialog-color
 2.0     November 2022
 =====================
 

--- a/openasip/src/applibs/hdb/HDBManager.cc
+++ b/openasip/src/applibs/hdb/HDBManager.cc
@@ -484,28 +484,14 @@ HDBManager::HDBManager(const std::string& hdbFile)
             // rename default_vhdl and default_verilog to initial_*
             // and add latency column
             dbConnection_->updateQuery(std::string(
-                "ALTER TABLE operation_implementation RENAME TO "
-                "operation_implementation_old"));
+                "ALTER TABLE operation_implementation ADD COLUMN "
+                "latency INTEGER;"));
             dbConnection_->updateQuery(std::string(
-                "CREATE TABLE operation_implementation ( "
-                "id INTEGER PRIMARY KEY, "
-                "latency INTEGER, "
-                "name TEXT NOT NULL, "
-                "bus_definition TEXT, "
-                "post_op_vhdl TEXT, "
-                "post_op_verilog TEXT, "
-                "initial_vhdl TEXT, "
-                "initial_verilog TEXT)"));
+                "ALTER TABLE operation_implementation RENAME COLUMN "
+                "default_vhdl TO initial_vhdl;"));
             dbConnection_->updateQuery(std::string(
-                "INSERT INTO operation_implementation "
-                    "(id, name, bus_definition, post_op_vhdl, post_op_verilog, "
-                    "initial_vhdl, initial_verilog) "
-                "SELECT id, name, bus_definition, post_op_vhdl, post_op_verilog, "
-                       "default_vhdl, default_verilog "
-                "FROM operation_implementation_old"));
-            dbConnection_->updateQuery(std::string(
-                "DROP TABLE operation_implementation_old"));
-
+                "ALTER TABLE operation_implementation RENAME COLUMN "
+                "default_verilog TO initial_verilog;"));
             dbConnection_->updateVersion(6);
         } catch (const RelationalDBException& exception) {
             throw IOException(


### PR DESCRIPTION
Fixes #212 

Note that currently no effort is made to fix old databases which may have invalid foreign keys due to the old code. ALTER TABLE RENAME COLUMN was added in version 3.25.0 of SQLite.