### PR TITLE
Fixes deprecation warning for boost::timer

### DIFF
--- a/openasip/src/applibs/Explorer/DesignSpaceExplorer.cc
+++ b/openasip/src/applibs/Explorer/DesignSpaceExplorer.cc
@@ -32,7 +32,6 @@
  * @note rating: red
  */
 
-#include <boost/timer.hpp>
 #include <sstream>
 #include <fstream>
 #include <algorithm>

--- a/openasip/src/applibs/Scheduler/Algorithms/BBSchedulerController.cc
+++ b/openasip/src/applibs/Scheduler/Algorithms/BBSchedulerController.cc
@@ -35,8 +35,6 @@
 #include <string>
 #include <cstdlib>
 
-#include <boost/timer.hpp>
-
 #include "BBSchedulerController.hh"
 #include "ControlFlowGraph.hh"
 #include "DataDependenceGraph.hh"

--- a/openasip/src/applibs/Scheduler/Algorithms/BUBasicBlockScheduler.cc
+++ b/openasip/src/applibs/Scheduler/Algorithms/BUBasicBlockScheduler.cc
@@ -265,7 +265,6 @@ BUBasicBlockScheduler::handleLoopDDG(
     ddg_ = &ddg;
     targetMachine_ = &targetMachine;
     minCycle_ = 0;
-    schedulingTime_.restart();
 
     if (renamer_ != NULL) {
         renamer_->initialize(ddg);

--- a/openasip/src/applibs/Scheduler/Algorithms/BasicBlockScheduler.cc
+++ b/openasip/src/applibs/Scheduler/Algorithms/BasicBlockScheduler.cc
@@ -35,8 +35,6 @@
 #include <string>
 #include <cstdlib>
 
-#include <boost/timer.hpp>
-
 #include "BasicBlockScheduler.hh"
 #include "DataDependenceGraph.hh"
 #include "SimpleResourceManager.hh"
@@ -113,7 +111,6 @@ BasicBlockScheduler::handleDDG(
     ddg_ = &ddg;
     targetMachine_ = &targetMachine;
     minCycle_ = minCycle;
-    schedulingTime_.restart();
 
     if (renamer_ != NULL) {
         renamer_->initialize(ddg);
@@ -259,7 +256,6 @@ BasicBlockScheduler::handleLoopDDG(
     ddg_ = &ddg;
     targetMachine_ = &targetMachine;
     minCycle_ = 0;
-    schedulingTime_.restart();
 
     if (renamer_ != NULL) {
         renamer_->initialize(ddg);

--- a/openasip/src/applibs/Scheduler/Algorithms/BasicBlockScheduler.hh
+++ b/openasip/src/applibs/Scheduler/Algorithms/BasicBlockScheduler.hh
@@ -34,7 +34,6 @@
 #ifndef TTA_BB_SCHEDULER_HH
 #define TTA_BB_SCHEDULER_HH
 
-#include <boost/timer.hpp>
 #include <boost/progress.hpp>
 
 #include "MoveNodeSelector.hh"
@@ -165,8 +164,6 @@ protected:
     int minCycle_;
 
     MoveNodeSelector* selector_;
-    /// Time for getting the scheduling time for current basic block.
-    boost::timer schedulingTime_;
     int bypassedCount_;
     int deadResults_;
 

--- a/openasip/src/applibs/Scheduler/Algorithms/ProgramPass.cc
+++ b/openasip/src/applibs/Scheduler/Algorithms/ProgramPass.cc
@@ -30,18 +30,19 @@
  * @note rating: red
  */
 
+#include "ProgramPass.hh"
+
 #include <boost/format.hpp>
 #include <chrono>
 #include <ctime>
 
-#include "ProgramPass.hh"
-#include "Program.hh"
-#include "ProcedurePass.hh"
 #include "Application.hh"
-#include "Procedure.hh"
-#include "POMDisassembler.hh"
-#include "InterPassDatum.hh"
 #include "InterPassData.hh"
+#include "InterPassDatum.hh"
+#include "POMDisassembler.hh"
+#include "Procedure.hh"
+#include "ProcedurePass.hh"
+#include "Program.hh"
 
 /**
  * Constructor.
@@ -77,8 +78,8 @@ ProgramPass::executeProcedurePass(
 
     FunctionNameList proceduresToProcess, proceduresToIgnore;
     if (procedurePass.interPassData().hasDatum("FUNCTIONS_TO_PROCESS")) {
-      proceduresToProcess = dynamic_cast<FunctionNameList &>(
-        procedurePass.interPassData().datum("FUNCTIONS_TO_PROCESS"));
+        proceduresToProcess = dynamic_cast<FunctionNameList&>(
+            procedurePass.interPassData().datum("FUNCTIONS_TO_PROCESS"));
     } else if (procedurePass.interPassData().hasDatum("FUNCTIONS_TO_IGNORE")) {
         proceduresToIgnore = 
             dynamic_cast<FunctionNameList&>(
@@ -123,24 +124,25 @@ ProgramPass::executeProcedurePass(
         ++proceduresDone;
 
         if (Application::verboseLevel() > 0) {
-          long currentElapsed =
-              std::chrono::duration_cast<std::chrono::seconds>(
-                  std::chrono::steady_clock::now() - currentTimeStart)
-                  .count();
-          long totalElapsed =
-              std::chrono::duration_cast<std::chrono::seconds>(
-                  std::chrono::steady_clock::now() - totalTimeStart)
-                  .count();
-          long eta = static_cast<long>((totalElapsed / proceduresDone) *
-                                       (totalProcedures - proceduresDone));
-          Application::logStream()
-              << (boost::format(
-                      " %d min %d s. Total %d min %d s. ETA in %d min %d s") %
-                  (currentElapsed / 60) % (currentElapsed % 60) %
-                  (totalElapsed / 60) % (totalElapsed % 60) % (eta / 60) %
-                  (eta % 60))
-                     .str()
-              << std::endl;
+            long currentElapsed =
+                std::chrono::duration_cast<std::chrono::seconds>(
+                    std::chrono::steady_clock::now() - currentTimeStart)
+                    .count();
+            long totalElapsed =
+                std::chrono::duration_cast<std::chrono::seconds>(
+                    std::chrono::steady_clock::now() - totalTimeStart)
+                    .count();
+            long eta = static_cast<long>(
+                (totalElapsed / proceduresDone) *
+                (totalProcedures - proceduresDone));
+            Application::logStream()
+                << (boost::format(" %d min %d s. Total %d min %d s. ETA in "
+                                  "%d min %d s") %
+                    (currentElapsed / 60) % (currentElapsed % 60) %
+                    (totalElapsed / 60) % (totalElapsed % 60) % (eta / 60) %
+                    (eta % 60))
+                       .str()
+                << std::endl;
         }
     }
 }

--- a/openasip/src/applibs/Scheduler/Algorithms/ProgramPass.cc
+++ b/openasip/src/applibs/Scheduler/Algorithms/ProgramPass.cc
@@ -73,11 +73,11 @@ void
 ProgramPass::executeProcedurePass(
     TTAProgram::Program& program, const TTAMachine::Machine& targetMachine,
     ProcedurePass& procedurePass) {
-  auto totalTimeStart = std::chrono::steady_clock::now();
+    auto totalTimeStart = std::chrono::steady_clock::now();
 
-  FunctionNameList proceduresToProcess, proceduresToIgnore;
-  if (procedurePass.interPassData().hasDatum("FUNCTIONS_TO_PROCESS")) {
-    proceduresToProcess = dynamic_cast<FunctionNameList &>(
+    FunctionNameList proceduresToProcess, proceduresToIgnore;
+    if (procedurePass.interPassData().hasDatum("FUNCTIONS_TO_PROCESS")) {
+      proceduresToProcess = dynamic_cast<FunctionNameList &>(
         procedurePass.interPassData().datum("FUNCTIONS_TO_PROCESS"));
     } else if (procedurePass.interPassData().hasDatum("FUNCTIONS_TO_IGNORE")) {
         proceduresToIgnore = 

--- a/openasip/src/applibs/Scheduler/ProgramRepresentations/CDG/ControlDependenceGraph.cc
+++ b/openasip/src/applibs/Scheduler/ProgramRepresentations/CDG/ControlDependenceGraph.cc
@@ -32,11 +32,10 @@
  * @note rating: red
  */
 
-#include <iostream>
-
 #include <algorithm>
 #include <chrono>
 #include <functional>
+#include <iostream>
 #include <list>
 #include <map>
 #include <vector>
@@ -369,7 +368,7 @@ ControlDependenceGraph::createPostDominanceTree(
     revGraph_ = &cGraph_->reversedGraph();
 
     bool modified = false;
-    int counter = 0; // NOLINT Disable claim this is unused
+    int counter = 0;  // NOLINT Disable claim this is unused
     std::vector<ControlFlowEdge*> addedEdges;
     BasicBlockNode& cfgExitNode = cGraph_->exitNode();
     do {
@@ -762,8 +761,8 @@ ControlDependenceGraph::analyzeCDG() {
     /// of each component
     int componentCount = detectStrongComponents(componentMap, rootMap);
     long elapsed = std::chrono::duration_cast<std::chrono::seconds>(
-                  std::chrono::steady_clock::now() - timer)
-                  .count();
+                       std::chrono::steady_clock::now() - timer)
+                       .count();
     if (Application::verboseLevel() > DEBUG_LEVEL) {
         Application::logStream() << (boost::format(
         "\t\tStrong components: %d components, %d minutes and %d seconds.\n")
@@ -781,7 +780,7 @@ ControlDependenceGraph::analyzeCDG() {
     /// boost::on_finish_vertex will give us post order numbering
     boost::time_stamper<CDGOrder, int, boost::on_finish_vertex>
         lastOrderStamper(lastOrder, fStamp);
-    timer = std::chrono::steady_clock::now(); // restart
+    timer = std::chrono::steady_clock::now();  // restart
     /// Sort nodes in post order, starting from entry node
     boost::depth_first_visit(
         graph_, descriptor(entryNode()),
@@ -795,7 +794,7 @@ ControlDependenceGraph::analyzeCDG() {
             % (elapsed/60) % (elapsed%60)).str();
     }
 
-    timer = std::chrono::steady_clock::now(); // restart
+    timer = std::chrono::steady_clock::now();  // restart
     /// Computes "region" information, for each node X, set of nodes that are
     /// executed when X is executed (for node Z, on all paths from X to entry,
     /// if node Z is region all children of Z will be in "region" of X
@@ -809,7 +808,7 @@ ControlDependenceGraph::analyzeCDG() {
             % (elapsed/60) % (elapsed%60)).str();
     }
 
-    timer = std::chrono::steady_clock::now(); // restart
+    timer = std::chrono::steady_clock::now();  // restart
     /// Computes "eec" information, for each node X, set of nodes that are
     /// executed when any node in subgraph of X is executed, computed using
     /// region information
@@ -823,7 +822,7 @@ ControlDependenceGraph::analyzeCDG() {
             % (elapsed/60) % (elapsed%60)).str();
     }
     analyzed_ = true;
-    timer = std::chrono::steady_clock::now(); // restart
+    timer = std::chrono::steady_clock::now();  // restart
 #if 0
     // This is really not needed, just for comparing with PDG edge generation
     // if necessary

--- a/openasip/src/applibs/Scheduler/ProgramRepresentations/CDG/ControlDependenceGraph.cc
+++ b/openasip/src/applibs/Scheduler/ProgramRepresentations/CDG/ControlDependenceGraph.cc
@@ -34,11 +34,12 @@
 
 #include <iostream>
 
-#include <vector>
 #include <algorithm>
+#include <chrono>
 #include <functional>
 #include <list>
 #include <map>
+#include <vector>
 
 // these need to be included before Boost so we include a working
 // and warning-free hash_map
@@ -48,14 +49,13 @@
 #include "CompilerWarnings.hh"
 IGNORE_CLANG_WARNING("-Wunused-local-typedef")
 IGNORE_COMPILER_WARNING("-Wunused-parameter")
-#include <boost/graph/reverse_graph.hpp>
-#include <boost/graph/depth_first_search.hpp>
-#include <boost/graph/breadth_first_search.hpp>
-#include <boost/graph/properties.hpp>
-#include <boost/graph/strong_components.hpp>
-#include <boost/graph/graph_utility.hpp>
-#include <boost/timer.hpp>
 #include <boost/format.hpp>
+#include <boost/graph/breadth_first_search.hpp>
+#include <boost/graph/depth_first_search.hpp>
+#include <boost/graph/graph_utility.hpp>
+#include <boost/graph/properties.hpp>
+#include <boost/graph/reverse_graph.hpp>
+#include <boost/graph/strong_components.hpp>
 POP_COMPILER_DIAGS
 POP_CLANG_DIAGS
 
@@ -369,7 +369,7 @@ ControlDependenceGraph::createPostDominanceTree(
     revGraph_ = &cGraph_->reversedGraph();
 
     bool modified = false;
-    int counter = 0;
+    int counter = 0; // NOLINT Disable claim this is unused
     std::vector<ControlFlowEdge*> addedEdges;
     BasicBlockNode& cfgExitNode = cGraph_->exitNode();
     do {
@@ -755,14 +755,15 @@ ControlDependenceGraph::analyzeCDG() {
 
     CDGOrderMap componentMap;
     DescriptorMap rootMap;
-    boost::timer timer;
+    auto timer = std::chrono::steady_clock::now();
     /// Find all strong components (loops) in a graph, loop entry nodes
     /// will have number identifying for which loop component they are entries
     /// and the strongComponents_ will contains all nodes that are part
     /// of each component
-    long elapsed = 0;
     int componentCount = detectStrongComponents(componentMap, rootMap);
-    elapsed = static_cast<long>(timer.elapsed());
+    long elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                  std::chrono::steady_clock::now() - timer)
+                  .count();
     if (Application::verboseLevel() > DEBUG_LEVEL) {
         Application::logStream() << (boost::format(
         "\t\tStrong components: %d components, %d minutes and %d seconds.\n")
@@ -780,48 +781,56 @@ ControlDependenceGraph::analyzeCDG() {
     /// boost::on_finish_vertex will give us post order numbering
     boost::time_stamper<CDGOrder, int, boost::on_finish_vertex>
         lastOrderStamper(lastOrder, fStamp);
-    timer.restart();
+    timer = std::chrono::steady_clock::now(); // restart
     /// Sort nodes in post order, starting from entry node
     boost::depth_first_visit(
         graph_, descriptor(entryNode()),
         boost::make_dfs_visitor(lastOrderStamper), colorsDFS);
-    elapsed = static_cast<long>(timer.elapsed());
+    elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                  std::chrono::steady_clock::now() - timer)
+                  .count();
     if (Application::verboseLevel() > DEBUG_LEVEL) {
         Application::logStream() << (boost::format(
             "\t\tPost order: %d minutes and %d seconds.\n")
             % (elapsed/60) % (elapsed%60)).str();
     }
 
-    timer.restart();
+    timer = std::chrono::steady_clock::now(); // restart
     /// Computes "region" information, for each node X, set of nodes that are
     /// executed when X is executed (for node Z, on all paths from X to entry,
     /// if node Z is region all children of Z will be in "region" of X
     computeRegionInfo(lastMap);
-    elapsed = static_cast<long>(timer.elapsed());
+    elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                  std::chrono::steady_clock::now() - timer)
+                  .count();
     if (Application::verboseLevel() > DEBUG_LEVEL) {
         Application::logStream() << (boost::format(
             "\t\tRegion: %d minutes and %d seconds.\n")
             % (elapsed/60) % (elapsed%60)).str();
     }
 
-    timer.restart();
+    timer = std::chrono::steady_clock::now(); // restart
     /// Computes "eec" information, for each node X, set of nodes that are
     /// executed when any node in subgraph of X is executed, computed using
     /// region information
     computeEECInfo(lastMap);
-    elapsed = static_cast<long>(timer.elapsed());
+    elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                  std::chrono::steady_clock::now() - timer)
+                  .count();
     if (Application::verboseLevel() > DEBUG_LEVEL) {
         Application::logStream() << (boost::format(
             "\t\tEEC: %d minutes and %d seconds.\n")
             % (elapsed/60) % (elapsed%60)).str();
     }
     analyzed_ = true;
-    timer.restart();
+    timer = std::chrono::steady_clock::now(); // restart
 #if 0
     // This is really not needed, just for comparing with PDG edge generation
     // if necessary
     computeRelations(lastMap);
-    elapsed = static_cast<long>(timer.elapsed());
+    elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                  std::chrono::steady_clock::now() - timer)
+                  .count();
     if (Application::verboseLevel() > DEBUG_LEVEL) {
         Application::logStream() << (boost::format(
             "\t\tRelations: %d minutes and %d seconds.\n")

--- a/openasip/src/applibs/Scheduler/ProgramRepresentations/PDG/ProgramDependenceGraph.cc
+++ b/openasip/src/applibs/Scheduler/ProgramRepresentations/PDG/ProgramDependenceGraph.cc
@@ -32,6 +32,7 @@
  */
 
 #include <utility>
+#include <chrono>
 
 // include this before boost to avoid deprecation
 // warnings
@@ -43,7 +44,6 @@
 #include <boost/graph/graph_utility.hpp>
 #include <boost/graph/topological_sort.hpp>
 #include <boost/graph/exception.hpp>
-#include <boost/timer.hpp>
 #include <boost/format.hpp>
 #include <boost/graph/graphviz.hpp>
 
@@ -409,7 +409,7 @@ ProgramDependenceGraph::serializePDG() {
     /// Created filtered PDG graph containing only control dependence edges
     CDGFilter<Graph> filter(graph_);
     FilteredCDG  filteredCDG = FilteredCDG(graph_, filter);
-    boost::timer timer;
+    auto timer = std::chrono::steady_clock::now();
     long elapsed = 0;
     /// Detect strong components if they were not detected in CDG and transferred
     if (!cdg_->analyzed()) {
@@ -418,7 +418,9 @@ ProgramDependenceGraph::serializePDG() {
         /// Modifies graph_ with added close nodes and close edges
         int componentCount = detectStrongComponents(
             componentMap, rootMap, filteredCDG);
-        elapsed = static_cast<long>(timer.elapsed());
+        elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                  std::chrono::steady_clock::now() - timer)
+                  .count();
         if (Application::verboseLevel() > DEBUG_LEVEL) {
             Application::logStream() << (boost::format(
             "\t\tStrong components:%d components, %d minutes and %d seconds.\n")
@@ -436,12 +438,14 @@ ProgramDependenceGraph::serializePDG() {
     /// boost::on_finish_vertex will give us post order numbering
     boost::time_stamper<PDGOrder, int, boost::on_finish_vertex>
         lastOrderStamper(lastOrder, fStamp);
-    timer.restart();
+    timer = std::chrono::steady_clock::now(); // restart
     /// Computes post order of all the nodes in PDG
     boost::depth_first_visit(
         filteredCDG, descriptor(entryNode()),
         boost::make_dfs_visitor(lastOrderStamper), colorsDFS);
-    elapsed = static_cast<long>(timer.elapsed());
+    elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                  std::chrono::steady_clock::now() - timer)
+                  .count();
     if (Application::verboseLevel() > DEBUG_LEVEL) {
         Application::logStream() << (boost::format(
             "\t\tPost order: %d minutes and %d seconds.\n")
@@ -450,9 +454,11 @@ ProgramDependenceGraph::serializePDG() {
     /// If not computed on CDG and copied, computes 'region' information for
     /// all nodes of a graph
     if (!cdg_->analyzed()) {
-        timer.restart();
+        timer = std::chrono::steady_clock::now(); // restart
         computeRegionInfo(lastMap, filteredCDG);
-        elapsed = static_cast<long>(timer.elapsed());
+        elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                  std::chrono::steady_clock::now() - timer)
+                  .count();
         if (Application::verboseLevel() > DEBUG_LEVEL) {
             Application::logStream() << (boost::format(
                 "\t\tRegion: %d minutes and %d seconds.\n")
@@ -460,9 +466,11 @@ ProgramDependenceGraph::serializePDG() {
         }
         /// If not computed on CDG and copied, computes 'eec' information for
         /// all nodes of a graph
-        timer.restart();
+        timer = std::chrono::steady_clock::now(); // restart
         computeEECInfo(lastMap, filteredCDG);
-        elapsed = static_cast<long>(timer.elapsed());
+        elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                  std::chrono::steady_clock::now() - timer)
+                  .count();
         if (Application::verboseLevel() > DEBUG_LEVEL) {
             Application::logStream() << (boost::format(
                 "\t\tEEC: %d minutes and %d seconds.\n")
@@ -470,7 +478,7 @@ ProgramDependenceGraph::serializePDG() {
         }
     }
 
-    timer.restart();
+    timer = std::chrono::steady_clock::now(); // restart
     /// If CDG comes analyzed we need to add region and eec info for
     /// dummy ENTRYNODE of DDG. By it's definition, ENTRYNODE is leaf
     /// in terms of control dependence, region == eec

--- a/openasip/src/applibs/Scheduler/ProgramRepresentations/PDG/ProgramDependenceGraph.cc
+++ b/openasip/src/applibs/Scheduler/ProgramRepresentations/PDG/ProgramDependenceGraph.cc
@@ -31,8 +31,8 @@
  * @note rating: red
  */
 
-#include <utility>
 #include <chrono>
+#include <utility>
 
 // include this before boost to avoid deprecation
 // warnings
@@ -419,8 +419,8 @@ ProgramDependenceGraph::serializePDG() {
         int componentCount = detectStrongComponents(
             componentMap, rootMap, filteredCDG);
         elapsed = std::chrono::duration_cast<std::chrono::seconds>(
-                  std::chrono::steady_clock::now() - timer)
-                  .count();
+                      std::chrono::steady_clock::now() - timer)
+                      .count();
         if (Application::verboseLevel() > DEBUG_LEVEL) {
             Application::logStream() << (boost::format(
             "\t\tStrong components:%d components, %d minutes and %d seconds.\n")
@@ -438,7 +438,7 @@ ProgramDependenceGraph::serializePDG() {
     /// boost::on_finish_vertex will give us post order numbering
     boost::time_stamper<PDGOrder, int, boost::on_finish_vertex>
         lastOrderStamper(lastOrder, fStamp);
-    timer = std::chrono::steady_clock::now(); // restart
+    timer = std::chrono::steady_clock::now();  // restart
     /// Computes post order of all the nodes in PDG
     boost::depth_first_visit(
         filteredCDG, descriptor(entryNode()),
@@ -454,11 +454,11 @@ ProgramDependenceGraph::serializePDG() {
     /// If not computed on CDG and copied, computes 'region' information for
     /// all nodes of a graph
     if (!cdg_->analyzed()) {
-        timer = std::chrono::steady_clock::now(); // restart
+        timer = std::chrono::steady_clock::now();  // restart
         computeRegionInfo(lastMap, filteredCDG);
         elapsed = std::chrono::duration_cast<std::chrono::seconds>(
-                  std::chrono::steady_clock::now() - timer)
-                  .count();
+                      std::chrono::steady_clock::now() - timer)
+                      .count();
         if (Application::verboseLevel() > DEBUG_LEVEL) {
             Application::logStream() << (boost::format(
                 "\t\tRegion: %d minutes and %d seconds.\n")
@@ -466,11 +466,11 @@ ProgramDependenceGraph::serializePDG() {
         }
         /// If not computed on CDG and copied, computes 'eec' information for
         /// all nodes of a graph
-        timer = std::chrono::steady_clock::now(); // restart
+        timer = std::chrono::steady_clock::now();  // restart
         computeEECInfo(lastMap, filteredCDG);
         elapsed = std::chrono::duration_cast<std::chrono::seconds>(
-                  std::chrono::steady_clock::now() - timer)
-                  .count();
+                      std::chrono::steady_clock::now() - timer)
+                      .count();
         if (Application::verboseLevel() > DEBUG_LEVEL) {
             Application::logStream() << (boost::format(
                 "\t\tEEC: %d minutes and %d seconds.\n")
@@ -478,7 +478,7 @@ ProgramDependenceGraph::serializePDG() {
         }
     }
 
-    timer = std::chrono::steady_clock::now(); // restart
+    timer = std::chrono::steady_clock::now();  // restart
     /// If CDG comes analyzed we need to add region and eec info for
     /// dummy ENTRYNODE of DDG. By it's definition, ENTRYNODE is leaf
     /// in terms of control dependence, region == eec

--- a/openasip/src/applibs/Simulator/NextiCommand.cc
+++ b/openasip/src/applibs/Simulator/NextiCommand.cc
@@ -79,8 +79,6 @@ NextiCommand::~NextiCommand() {
  */
 bool
 NextiCommand::execute(const std::vector<DataObject>& arguments) {
-    boost::timer time;    
-
     const int argumentCount = arguments.size() - 1;
     if (!checkArgumentCount(argumentCount, 0, 1)) {
         return false;

--- a/openasip/src/applibs/Simulator/SimulatorFrontend.hh
+++ b/openasip/src/applibs/Simulator/SimulatorFrontend.hh
@@ -39,7 +39,6 @@
 #include <ostream>
 #include <ctime>
 
-#include <boost/timer.hpp>
 #include <set>
 
 #include "Exception.hh"

--- a/openasip/src/applibs/Simulator/UntilCommand.cc
+++ b/openasip/src/applibs/Simulator/UntilCommand.cc
@@ -43,7 +43,6 @@
 #include "Procedure.hh"
 
 #include <iostream>
-#include <boost/timer.hpp>
 
 /**
  * Constructor.
@@ -73,9 +72,7 @@ UntilCommand::~UntilCommand() {
  * @exception NumberFormatException Is never thrown by this command.
  */
 bool
-UntilCommand::execute(const std::vector<DataObject>& arguments) {
-    boost::timer time;
-    
+UntilCommand::execute(const std::vector<DataObject>& arguments) {    
     const int argumentCount = arguments.size() - 1;
     if (!checkArgumentCount(argumentCount, 0, 1)) {
         return false;

--- a/openasip/src/applibs/Simulator/UntilCommand.cc
+++ b/openasip/src/applibs/Simulator/UntilCommand.cc
@@ -72,7 +72,7 @@ UntilCommand::~UntilCommand() {
  * @exception NumberFormatException Is never thrown by this command.
  */
 bool
-UntilCommand::execute(const std::vector<DataObject>& arguments) {    
+UntilCommand::execute(const std::vector<DataObject>& arguments) {
     const int argumentCount = arguments.size() - 1;
     if (!checkArgumentCount(argumentCount, 0, 1)) {
         return false;

--- a/openasip/test/applibs/Simulator/FUStateTest/FUStateTest.hh
+++ b/openasip/test/applibs/Simulator/FUStateTest/FUStateTest.hh
@@ -430,7 +430,7 @@ FUStateTest::testMemoryAccessingFUState() {
 
 #ifdef CONFLICT_DETECTOR_BENCHMARK 
 
-#include <boost/timer.hpp>
+#include <chrono>
 #include <iostream>
 
 #define INIT_COUNT 100000
@@ -439,7 +439,7 @@ FUStateTest::testMemoryAccessingFUState() {
 #define BENCHMARK_INIT(FU_MACH, CREATE_DETECTOR) \
     std::cout.flush(); \
 \
-    t.restart(); \
+    timer = std::chrono::steady_clock::now();  \
     for (int count = 0; count < INIT_COUNT; ++count) {\
         FUConflictDetectorIndex detectors;\
         MachineStateBuilder builder;\
@@ -450,14 +450,16 @@ FUStateTest::testMemoryAccessingFUState() {
         delete builder.build(srcMach, memSys, detectors, false);\
         delete detector;\
     }\
-    last = t.elapsed();\
+    last = std::chrono::duration_cast<std::chrono::seconds>( \
+                  std::chrono::steady_clock::now() - timer) \
+                  .count();\
     std::cout << last << "s ";\
     std::cout.flush()
 
 #define BENCHMARK_INITIALIZATION(FU_MACH, CREATE_DETECTOR) {\
     std::cout \
         << "Initializing " #FU_MACH " " << INIT_COUNT << " times..."; \
-    boost::timer t;\
+    auto timer = std::chrono::steady_clock::now(); \
     double best = DBL_MAX;\
     double last = 0.0;\
     const TTAMachine::Machine& srcMach = *FU_MACH##Mach;\
@@ -538,7 +540,7 @@ FUStateTest::benchmarkInitLazyFSA() {
     {\
         std::cout \
             << "Executing operations in " #FU_MACH " " << EXEC_COUNT << " times..."; \
-        boost::timer t;\
+        auto timer = std::chrono::steady_clock::now();\
         std::cout.flush();\
         double best = DBL_MAX;\
         double last = 0.0;\
@@ -575,14 +577,16 @@ FUStateTest::benchmarkInitLazyFSA() {
                execMoves.push_back(new BuslessExecutableMove(immediateSource, port));\
             }\
 \
-            t.restart();\
+            timer = std::chrono::steady_clock::now(); \
             for (int i = 0; i < EXEC_COUNT; ++i) {\
                 execMoves.at(i % execMoves.size())->executeWrite();\
                 fuState.endClock();\
                 fuState.advanceClock();\
             }\
 \
-            last = t.elapsed();\
+            last = std::chrono::duration_cast<std::chrono::seconds>( \
+                  std::chrono::steady_clock::now() - timer) \
+                  .count();\
 \
             std::cout << last << "s ";\
             std::cout.flush();\

--- a/openasip/test/applibs/Simulator/FUStateTest/FUStateTest.hh
+++ b/openasip/test/applibs/Simulator/FUStateTest/FUStateTest.hh
@@ -428,7 +428,7 @@ FUStateTest::testMemoryAccessingFUState() {
     TS_ASSERT_EQUALS(output.value().intValue(), 10);
 }
 
-#ifdef CONFLICT_DETECTOR_BENCHMARK 
+#ifdef CONFLICT_DETECTOR_BENCHMARK
 
 #include <chrono>
 #include <iostream>
@@ -436,44 +436,45 @@ FUStateTest::testMemoryAccessingFUState() {
 #define INIT_COUNT 100000
 #define EXEC_COUNT 10000000
 
-#define BENCHMARK_INIT(FU_MACH, CREATE_DETECTOR) \
-    std::cout.flush(); \
-\
-    timer = std::chrono::steady_clock::now();  \
-    for (int count = 0; count < INIT_COUNT; ++count) {\
-        FUConflictDetectorIndex detectors;\
-        MachineStateBuilder builder;\
-        FUResourceConflictDetector* detector = CREATE_DETECTOR;\
-        if (detector != NULL) detectors[#FU_MACH] = detector;\
-        MemorySystem memSys(srcMach);\
-\
-        delete builder.build(srcMach, memSys, detectors, false);\
-        delete detector;\
-    }\
-    last = std::chrono::duration_cast<std::chrono::seconds>( \
-                  std::chrono::steady_clock::now() - timer) \
-                  .count();\
-    std::cout << last << "s ";\
+#define BENCHMARK_INIT(FU_MACH, CREATE_DETECTOR)                 \
+    std::cout.flush();                                           \
+                                                                 \
+    timer = std::chrono::steady_clock::now();                    \
+    for (int count = 0; count < INIT_COUNT; ++count) {           \
+        FUConflictDetectorIndex detectors;                       \
+        MachineStateBuilder builder;                             \
+        FUResourceConflictDetector* detector = CREATE_DETECTOR;  \
+        if (detector != NULL) detectors[#FU_MACH] = detector;    \
+        MemorySystem memSys(srcMach);                            \
+                                                                 \
+        delete builder.build(srcMach, memSys, detectors, false); \
+        delete detector;                                         \
+    }                                                            \
+    last = std::chrono::duration_cast<std::chrono::seconds>(     \
+               std::chrono::steady_clock::now() - timer)         \
+               .count();                                         \
+    std::cout << last << "s ";                                   \
     std::cout.flush()
 
-#define BENCHMARK_INITIALIZATION(FU_MACH, CREATE_DETECTOR) {\
-    std::cout \
-        << "Initializing " #FU_MACH " " << INIT_COUNT << " times..."; \
-    auto timer = std::chrono::steady_clock::now(); \
-    double best = DBL_MAX;\
-    double last = 0.0;\
-    const TTAMachine::Machine& srcMach = *FU_MACH##Mach;\
-    const TTAMachine::FunctionUnit& fu = \
-        *srcMach.functionUnitNavigator().item(0); \
-\
-    for (int i = 0; i < 3; ++i) {\
-        BENCHMARK_INIT(FU_MACH, CREATE_DETECTOR);\
-        best = std::min(best, last);\
-    }\
-\
-    std::cout \
-      << " best=" << best << " average=" << best/INIT_COUNT << std::endl;}
-
+#define BENCHMARK_INITIALIZATION(FU_MACH, CREATE_DETECTOR)                \
+    {                                                                     \
+        std::cout << "Initializing " #FU_MACH " " << INIT_COUNT           \
+                  << " times...";                                         \
+        auto timer = std::chrono::steady_clock::now();                    \
+        double best = DBL_MAX;                                            \
+        double last = 0.0;                                                \
+        const TTAMachine::Machine& srcMach = *FU_MACH##Mach;              \
+        const TTAMachine::FunctionUnit& fu =                              \
+            *srcMach.functionUnitNavigator().item(0);                     \
+                                                                          \
+        for (int i = 0; i < 3; ++i) {                                     \
+            BENCHMARK_INIT(FU_MACH, CREATE_DETECTOR);                     \
+            best = std::min(best, last);                                  \
+        }                                                                 \
+                                                                          \
+        std::cout << " best=" << best << " average=" << best / INIT_COUNT \
+                  << std::endl;                                           \
+    }
 
 /**
  * Bechmark the different conflict detection models.
@@ -535,72 +536,72 @@ FUStateTest::benchmarkInitLazyFSA() {
     BENCHMARK_INITIALIZATION(fpu, CREATOR_LFSA);
 }
 
-
-#define BENCHMARK_SIMULATION(FU_MACH, CREATE_DETECTOR) \
-    {\
-        std::cout \
-            << "Executing operations in " #FU_MACH " " << EXEC_COUNT << " times..."; \
-        auto timer = std::chrono::steady_clock::now();\
-        std::cout.flush();\
-        double best = DBL_MAX;\
-        double last = 0.0;\
-        const TTAMachine::Machine& srcMach = *FU_MACH##Mach;\
-        const TTAMachine::FunctionUnit& fu = \
-           *srcMach.functionUnitNavigator().item(0); \
-\
-        for (int repeat = 0; repeat < 3; ++repeat) {\
-            FUConflictDetectorIndex detectors;\
-            MachineStateBuilder builder;\
-            FUResourceConflictDetector* detector = CREATE_DETECTOR;\
-            if (detector != NULL) detectors[#FU_MACH] = detector;\
-            MemorySystem memSys(srcMach);\
-\
-            MachineState* msm = NULL;\
-            CATCH_ANY(msm = builder.build(srcMach, memSys, detectors, false));\
-            FUState& fuState = msm->fuState(#FU_MACH);\
-\
-            std::vector<ExecutableMove*> execMoves;\
-            for (int i = 0; i < FU_MACH##Operations.size(); ++i) {\
-                InlineImmediateValue* immediateSource = \
-                    new InlineImmediateValue(1);\
-               int immediate = 1;\
-               SimValue val(immediate, 1);\
-               immediateSource->setValue(val);\
-\
-               Operation* op = FU_MACH##Operations.at(i);\
-               assert(op != NULL);\
-               std::string portName = \
-                   std::string("t.") + StringTools::stringToLower(op->name());\
-               PortState& port = msm->portState(\
-                   portName, #FU_MACH);\
-               assert(&port != &NullPortState::instance());\
-               execMoves.push_back(new BuslessExecutableMove(immediateSource, port));\
-            }\
-\
-            timer = std::chrono::steady_clock::now(); \
-            for (int i = 0; i < EXEC_COUNT; ++i) {\
-                execMoves.at(i % execMoves.size())->executeWrite();\
-                fuState.endClock();\
-                fuState.advanceClock();\
-            }\
-\
-            last = std::chrono::duration_cast<std::chrono::seconds>( \
-                  std::chrono::steady_clock::now() - timer) \
-                  .count();\
-\
-            std::cout << last << "s ";\
-            std::cout.flush();\
-\
-            delete detector;\
-            delete msm;\
-            AssocTools::deleteAllItems(execMoves);\
-\
-            best = std::min(best, last);\
-        }\
-\
-        std::cout \
-            << " best=" << best << " average=" << best/EXEC_COUNT << std::endl;\
-\
+#define BENCHMARK_SIMULATION(FU_MACH, CREATE_DETECTOR)                     \
+    {                                                                      \
+        std::cout << "Executing operations in " #FU_MACH " " << EXEC_COUNT \
+                  << " times...";                                          \
+        auto timer = std::chrono::steady_clock::now();                     \
+        std::cout.flush();                                                 \
+        double best = DBL_MAX;                                             \
+        double last = 0.0;                                                 \
+        const TTAMachine::Machine& srcMach = *FU_MACH##Mach;               \
+        const TTAMachine::FunctionUnit& fu =                               \
+            *srcMach.functionUnitNavigator().item(0);                      \
+                                                                           \
+        for (int repeat = 0; repeat < 3; ++repeat) {                       \
+            FUConflictDetectorIndex detectors;                             \
+            MachineStateBuilder builder;                                   \
+            FUResourceConflictDetector* detector = CREATE_DETECTOR;        \
+            if (detector != NULL) detectors[#FU_MACH] = detector;          \
+            MemorySystem memSys(srcMach);                                  \
+                                                                           \
+            MachineState* msm = NULL;                                      \
+            CATCH_ANY(                                                     \
+                msm = builder.build(srcMach, memSys, detectors, false));   \
+            FUState& fuState = msm->fuState(#FU_MACH);                     \
+                                                                           \
+            std::vector<ExecutableMove*> execMoves;                        \
+            for (int i = 0; i < FU_MACH##Operations.size(); ++i) {         \
+                InlineImmediateValue* immediateSource =                    \
+                    new InlineImmediateValue(1);                           \
+                int immediate = 1;                                         \
+                SimValue val(immediate, 1);                                \
+                immediateSource->setValue(val);                            \
+                                                                           \
+                Operation* op = FU_MACH##Operations.at(i);                 \
+                assert(op != NULL);                                        \
+                std::string portName =                                     \
+                    std::string("t.") +                                    \
+                    StringTools::stringToLower(op->name());                \
+                PortState& port = msm->portState(portName, #FU_MACH);      \
+                assert(&port != &NullPortState::instance());               \
+                execMoves.push_back(                                       \
+                    new BuslessExecutableMove(immediateSource, port));     \
+            }                                                              \
+                                                                           \
+            timer = std::chrono::steady_clock::now();                      \
+            for (int i = 0; i < EXEC_COUNT; ++i) {                         \
+                execMoves.at(i % execMoves.size())->executeWrite();        \
+                fuState.endClock();                                        \
+                fuState.advanceClock();                                    \
+            }                                                              \
+                                                                           \
+            last = std::chrono::duration_cast<std::chrono::seconds>(       \
+                       std::chrono::steady_clock::now() - timer)           \
+                       .count();                                           \
+                                                                           \
+            std::cout << last << "s ";                                     \
+            std::cout.flush();                                             \
+                                                                           \
+            delete detector;                                               \
+            delete msm;                                                    \
+            AssocTools::deleteAllItems(execMoves);                         \
+                                                                           \
+            best = std::min(best, last);                                   \
+        }                                                                  \
+                                                                           \
+        std::cout << " best=" << best << " average=" << best / EXEC_COUNT  \
+                  << std::endl;                                            \
     }
 
 void

--- a/openasip/test/applibs/mach/PipelineResourceModelBenchMarkTest/PipelineResourceModelBenchMarkTest.hh
+++ b/openasip/test/applibs/mach/PipelineResourceModelBenchMarkTest/PipelineResourceModelBenchMarkTest.hh
@@ -36,7 +36,7 @@
 #include <TestSuite.h>
 #include <string>
 #include <fstream>
-#include <boost/timer.hpp>
+#include <chrono>
 
 #include "Machine.hh"
 #include "ReservationTableFUResourceConflictDetector.hh"
@@ -82,12 +82,14 @@ PipelineResourceModelBenchMarkTest::PipelineResourceModelBenchMarkTest() :
     double best = DBL_MAX;\
     double worst = 0.0;\
     for (int round = 0; round < INITIALIZATION_ROUNDS; ++round) {\
-        boost::timer t; \
+        auto timer = std::chrono::steady_clock::now(); \
         for (int i = 0; i < INITIALIZATION_COUNT; ++i) {\
             DETECTOR__ d(*FU__);                        \
             CODE__;\
         }\
-        double val = t.elapsed();\
+        double val = std::chrono::duration_cast<std::chrono::seconds>( \
+                  std::chrono::steady_clock::now() - timer) \
+                  .count();\
         Application::logStream() \
             << #FU__ << " round " << round << ": " << val << " s (" \
             << val / INITIALIZATION_COUNT << " on avg)" << std::endl;\
@@ -119,7 +121,7 @@ void
 PipelineResourceModelBenchMarkTest::testInitialization() {
 #if defined(BENCHMARKING_ENABLED) && defined(INIT_BENCHMARK)
 
-    boost::timer t;
+    auto timer = std::chrono::steady_clock::now();
     Application::logStream() 
         << "INITIALIZATION_ROUNDS " << INITIALIZATION_ROUNDS << std::endl
         << "INITIALIZATION_COUNT " << INITIALIZATION_COUNT << std::endl;
@@ -139,13 +141,15 @@ PipelineResourceModelBenchMarkTest::testInitialization() {
     for (int round = 0; round < SIMULATION_ROUNDS; ++round) {\
         DETECTOR__ d(*FU__);                                 \
         CODE__;                                              \
-        boost::timer t; \
+        auto timer = std::chrono::steady_clock::now(); \
         for (unsigned i = 0; i < SIMULATED_OPERATION_COUNT; ++i) {\
             const int op = i % (operations); \
             d.ISSUE__(op);\
             d.advanceCycleInline();\
         }                                                               \
-        double val = t.elapsed();                                       \
+        double val = std::chrono::duration_cast<std::chrono::seconds>(  \
+                  std::chrono::steady_clock::now() - timer)             \
+                  .count();                                             \
         Application::logStream()                                        \
         << #FU__ << " round " << round << ": " << val << " s ("         \
         << SIMULATED_OPERATION_COUNT/(val*1e6) << " Mops)" << std::endl; \

--- a/openasip/test/applibs/mach/PipelineResourceModelBenchMarkTest/PipelineResourceModelBenchMarkTest.hh
+++ b/openasip/test/applibs/mach/PipelineResourceModelBenchMarkTest/PipelineResourceModelBenchMarkTest.hh
@@ -34,14 +34,14 @@
 #define PIPELINE_RESOURCE_MODEL_BENCHMARK_TEST_HH
 
 #include <TestSuite.h>
-#include <string>
-#include <fstream>
-#include <chrono>
 
-#include "Machine.hh"
-#include "ReservationTableFUResourceConflictDetector.hh"
+#include <chrono>
+#include <fstream>
+#include <string>
+
 #include "DCMFUResourceConflictDetector.hh"
 #include "FSAFUResourceConflictDetector.hh"
+#include "Machine.hh"
 #include "ReservationTableFUResourceConflictDetector.hh"
 
 class PipelineResourceModelBenchMarkTest : public CxxTest::TestSuite {
@@ -77,34 +77,33 @@ PipelineResourceModelBenchMarkTest::PipelineResourceModelBenchMarkTest() :
 
 #include <cfloat>
 
-#define INIT_DETECTOR(DETECTOR__, FU__, CODE__) {       \
-    double total = 0.0;\
-    double best = DBL_MAX;\
-    double worst = 0.0;\
-    for (int round = 0; round < INITIALIZATION_ROUNDS; ++round) {\
-        auto timer = std::chrono::steady_clock::now(); \
-        for (int i = 0; i < INITIALIZATION_COUNT; ++i) {\
-            DETECTOR__ d(*FU__);                        \
-            CODE__;\
-        }\
-        double val = std::chrono::duration_cast<std::chrono::seconds>( \
-                  std::chrono::steady_clock::now() - timer) \
-                  .count();\
-        Application::logStream() \
-            << #FU__ << " round " << round << ": " << val << " s (" \
-            << val / INITIALIZATION_COUNT << " on avg)" << std::endl;\
-        if (val > worst)\
-            worst = val;\
-        if (val < best)\
-            best = val;\
-        total += val;\
-    }\
-\
-    Application::logStream()\
-        << "=== best: " << best << " worst: " << worst\
-        << " average: " << total / INITIALIZATION_ROUNDS\
-        << std::endl << std::endl;\
-}
+#define INIT_DETECTOR(DETECTOR__, FU__, CODE__)                            \
+    {                                                                      \
+        double total = 0.0;                                                \
+        double best = DBL_MAX;                                             \
+        double worst = 0.0;                                                \
+        for (int round = 0; round < INITIALIZATION_ROUNDS; ++round) {      \
+            auto timer = std::chrono::steady_clock::now();                 \
+            for (int i = 0; i < INITIALIZATION_COUNT; ++i) {               \
+                DETECTOR__ d(*FU__);                                       \
+                CODE__;                                                    \
+            }                                                              \
+            double val = std::chrono::duration_cast<std::chrono::seconds>( \
+                             std::chrono::steady_clock::now() - timer)     \
+                             .count();                                     \
+            Application::logStream()                                       \
+                << #FU__ << " round " << round << ": " << val << " s ("    \
+                << val / INITIALIZATION_COUNT << " on avg)" << std::endl;  \
+            if (val > worst) worst = val;                                  \
+            if (val < best) best = val;                                    \
+            total += val;                                                  \
+        }                                                                  \
+                                                                           \
+        Application::logStream()                                           \
+            << "=== best: " << best << " worst: " << worst                 \
+            << " average: " << total / INITIALIZATION_ROUNDS << std::endl  \
+            << std::endl;                                                  \
+    }
 
 #define INIT(CLASS__, ADDITIONAL_CODE__) \
     Application::logStream() \
@@ -133,38 +132,38 @@ PipelineResourceModelBenchMarkTest::testInitialization() {
 #endif
 }
 
-#define SIMULATE_DETECTOR(DETECTOR__, FU__, CODE__, ISSUE__) {  \
-    double total = 0.0;                                     \
-    double best = DBL_MAX;\
-    double worst = 0.0;\
-    const int operations = FU__->operationCount();      \
-    for (int round = 0; round < SIMULATION_ROUNDS; ++round) {\
-        DETECTOR__ d(*FU__);                                 \
-        CODE__;                                              \
-        auto timer = std::chrono::steady_clock::now(); \
-        for (unsigned i = 0; i < SIMULATED_OPERATION_COUNT; ++i) {\
-            const int op = i % (operations); \
-            d.ISSUE__(op);\
-            d.advanceCycleInline();\
-        }                                                               \
-        double val = std::chrono::duration_cast<std::chrono::seconds>(  \
-                  std::chrono::steady_clock::now() - timer)             \
-                  .count();                                             \
-        Application::logStream()                                        \
-        << #FU__ << " round " << round << ": " << val << " s ("         \
-        << SIMULATED_OPERATION_COUNT/(val*1e6) << " Mops)" << std::endl; \
-        if (val > worst)\
-            worst = val;\
-        if (val < best)\
-            best = val;\
-        total += val;\
-    }\
-\
-    Application::logStream()\
-        << "=== best: " << best << " worst: " << worst\
-        << " average: " << total / SIMULATION_ROUNDS\
-        << std::endl << std::endl;\
-}
+#define SIMULATE_DETECTOR(DETECTOR__, FU__, CODE__, ISSUE__)               \
+    {                                                                      \
+        double total = 0.0;                                                \
+        double best = DBL_MAX;                                             \
+        double worst = 0.0;                                                \
+        const int operations = FU__->operationCount();                     \
+        for (int round = 0; round < SIMULATION_ROUNDS; ++round) {          \
+            DETECTOR__ d(*FU__);                                           \
+            CODE__;                                                        \
+            auto timer = std::chrono::steady_clock::now();                 \
+            for (unsigned i = 0; i < SIMULATED_OPERATION_COUNT; ++i) {     \
+                const int op = i % (operations);                           \
+                d.ISSUE__(op);                                             \
+                d.advanceCycleInline();                                    \
+            }                                                              \
+            double val = std::chrono::duration_cast<std::chrono::seconds>( \
+                             std::chrono::steady_clock::now() - timer)     \
+                             .count();                                     \
+            Application::logStream()                                       \
+                << #FU__ << " round " << round << ": " << val << " s ("    \
+                << SIMULATED_OPERATION_COUNT / (val * 1e6) << " Mops)"     \
+                << std::endl;                                              \
+            if (val > worst) worst = val;                                  \
+            if (val < best) best = val;                                    \
+            total += val;                                                  \
+        }                                                                  \
+                                                                           \
+        Application::logStream()                                           \
+            << "=== best: " << best << " worst: " << worst                 \
+            << " average: " << total / SIMULATION_ROUNDS << std::endl      \
+            << std::endl;                                                  \
+    }
 
 #define SIMULATE(CLASS__, ADDITIONAL_CODE__, ISSUE__)   \
     Application::logStream() \

--- a/openasip/tools/scripts/clang-format-diff.py
+++ b/openasip/tools/scripts/clang-format-diff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 #
 #===- clang-format-diff.py - ClangFormat Diff Reformatter ----*- python -*--===#
 #

--- a/openasip/tools/scripts/format-branch.sh
+++ b/openasip/tools/scripts/format-branch.sh
@@ -13,7 +13,7 @@ if [ ! -d .git ]; then
   fi
 fi
 
-REF_BRANCH=${1:-origin/master}
+REF_BRANCH=${1:-origin/main}
 SCRIPTDIR=openasip/tools/scripts
 
 echo "Diffing against ${REF_BRANCH}..."
@@ -21,7 +21,7 @@ echo "Diffing against ${REF_BRANCH}..."
 PATCHY=/tmp/p.patch
 
 rm -f $PATCHY
-git diff master -U0 --no-color >$PATCHY
+git diff main -U0 --no-color >$PATCHY
 
 $SCRIPTDIR/clang-format-diff.py \
  -regex '(.*(\.hh$|\.cc$|\.c$|\.h$))' \


### PR DESCRIPTION
The code was using boost::timer version 1 while Boost has moved to a new API. The new timer API is very similar to the one introduced in C++ 11, so I just went with C++11.

Notes:

1. To reset the timer,  just allocate a new one.
2. To calculate elapsed time,  subtract the timer from now (a new timer)
3. Then cast the result to the desired granularity. This code is casting to seconds to match the original.
