### PR TITLE
explorer: Fix "--pareto_set" if more than 1 app is in the Database

### DIFF
--- a/openasip/src/codesign/Explorer/pareto_vis
+++ b/openasip/src/codesign/Explorer/pareto_vis
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
     Copyright (c) 2002-2011 Tampere University.
@@ -40,8 +40,8 @@ import sys
 try:
    from pylab import *
 except:
-   print "Requires Matplotlib. Install it, for example using:"
-   print 'apt-get install python-matplotlib'
+   print("Requires Matplotlib. Install it, for example using:")
+   print('apt-get install python-matplotlib')
    sys.exit(1)
 
 def plot_data():
@@ -54,7 +54,7 @@ def plot_data():
       if header is None:
          header_pieces = [x.strip() for x in line.split('|')[0:3]]
          if header_pieces != ["conf #", "conn", "cycles"]:
-            print "Unsupported table header", header_pieces
+            print("Unsupported table header", header_pieces)
             sys.exit(1)
          header = ("conf #", "connections", "instruction cycles")
          continue
@@ -88,13 +88,9 @@ if __name__ == "__main__":
    elif len(sys.argv) == 2:
       try:
          savefig(sys.argv[1])
-      except Exception, e:
-         print e
+      except Exception as e:
+         print(e)
          sys.exit(1)
    else:
-      print "Illegal number of arguments. "
-      print "Usage: explore --pareto_set C myresults.dsdb | pareto_vis [imagefn]"
-
-
-
-
+      print("Illegal number of arguments. ")
+      print("Usage: explore --pareto_set C myresults.dsdb | pareto_vis [imagefn]")


### PR DESCRIPTION
Currently `DSDBManager::paretoSetConnectivityAndCycles()` is always called with the default argument of "-1", meaning that all applications should be taken in to account. This would trigger an assert if there was more than one in the database.

This commit changes the behavior to use the average cycle count in this case. This metric is also used in other places like `ConnectionSweeper`.

Also convert the `pareto_viz` script to Python 3.