### PR TITLE
Misc fixes

### DIFF
--- a/openasip/data/ProGe/rv32_ifetch.vhdl.tmpl
+++ b/openasip/data/ProGe/rv32_ifetch.vhdl.tmpl
@@ -23,11 +23,11 @@
 library IEEE;
 use IEEE.Std_Logic_1164.all;
 use IEEE.numeric_std.all;
-use work.tta0_globals.all;
-use work.tta0_gcu_opcodes.all;
-use work.tta0_imem_mau.all;
+use work.ENTITY_STR_globals.all;
+use work.ENTITY_STR_gcu_opcodes.all;
+use work.ENTITY_STR_imem_mau.all;
 
-entity tta0_ifetch is
+entity ENTITY_STR_ifetch is
   generic (
     debug_logic_g              : boolean   := false;
     bypass_fetchblock_register : boolean := false;
@@ -72,9 +72,9 @@ entity tta0_ifetch is
 
     clk  : in std_logic;
     rstx : in std_logic);
-end tta0_ifetch;
+end ENTITY_STR_ifetch;
 
-architecture rtl_andor of tta0_ifetch is
+architecture rtl_andor of ENTITY_STR_ifetch is
 
   -- signals for program counter
   signal pc_reg      : std_logic_vector (IMEMADDRWIDTH-1 downto 0);

--- a/openasip/data/ProGe/rv32_microcode_wrapper.vhdl.tmpl
+++ b/openasip/data/ProGe/rv32_microcode_wrapper.vhdl.tmpl
@@ -27,7 +27,7 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 use ieee.std_logic_misc.all;
-use work.tta0_globals.all;
+use work.ENTITY_STR_globals.all;
 use STD.textio.all;
 use ieee.std_logic_textio.all;
 use IEEE.math_real.all;

--- a/openasip/icdecoder_plugins/DefaultICDecoderPlugin.cc
+++ b/openasip/icdecoder_plugins/DefaultICDecoderPlugin.cc
@@ -1422,7 +1422,7 @@ public:
                 IFETCH_STALL_PORT_NAME + " : in std_logic;");
 
             ProGe::RV32MicroCodeGenerator* microCodeGen =
-                new RV32MicroCodeGenerator(ttamachine_, bem_);
+                new RV32MicroCodeGenerator(ttamachine_, bem_, entityString);
             microCodeGen->setBypassInstructionRegister(
                 bypassInstructionRegister());
             microCodeGen->generateRTL(instantiator, dstDirectory);

--- a/openasip/src/applibs/ImplementationTester/GhdlSimulator.cc
+++ b/openasip/src/applibs/ImplementationTester/GhdlSimulator.cc
@@ -118,7 +118,7 @@ GhdlSimulator::importFile(
 }
 
 bool GhdlSimulator::compileDesign(std::vector<std::string>& errors) {
-    string command = "ghdl  -m --ieee=synopsys --workdir=" 
+    string command = "ghdl  -m -Wno-hide --ieee=synopsys --workdir=" 
         + workDir() + " testbench 2>&1";
     if (verbose()) {
         // TODO: get output stream

--- a/openasip/src/applibs/ProGe/MicroCodeGenerator.hh
+++ b/openasip/src/applibs/ProGe/MicroCodeGenerator.hh
@@ -36,6 +36,7 @@ namespace TTAMachine {
     class Port;
 }
 
+class BinaryEncoding;
 class InstructionBitVector;
 class HDLTemplateInstantiator;
 
@@ -46,7 +47,9 @@ namespace ProGe {
 class MicroCodeGenerator {
 
 public:
-    MicroCodeGenerator() = default;
+    MicroCodeGenerator(const Machine& machine, const BinaryEncoding& bem,
+    const std::string& entityName)
+    : machine_(&machine), bem_(&bem), entityName_(entityName) {};
     ~MicroCodeGenerator() = default;
 
     virtual void generateRTL(HDLTemplateInstantiator& instantiator,
@@ -56,7 +59,10 @@ public:
         Bus* bus;
         Port* port;
     };
-
+protected:
+    const Machine* machine_;
+    const BinaryEncoding* bem_;
+    const std::string entityName_;
 };
 }
 #endif

--- a/openasip/src/applibs/ProGe/ProGeScriptGenerator.cc
+++ b/openasip/src/applibs/ProGe/ProGeScriptGenerator.cc
@@ -265,11 +265,8 @@ ProGeScriptGenerator::generateGhdlCompile(
         stream << endl;
     }
     // compile command for ghdl
-
-    stream << "if [ \"$only_add_files\" = \"no\" ]; then" << endl;
-    stream << "    ghdl -m --workdir=" << workDir_
-           << " --ieee=synopsys -fexplicit " << tbName << endl;
-    stream << "fi" << endl;
+    stream << "ghdl -m --workdir=" << workDir_ 
+           << " --ieee=synopsys -fexplicit -Wno-hide " << testbenchName_ << endl;
 
     stream << "exit 0" << endl;
     stream.close();

--- a/openasip/src/applibs/ProGe/RV32MicroCodeGenerator.cc
+++ b/openasip/src/applibs/ProGe/RV32MicroCodeGenerator.cc
@@ -79,9 +79,10 @@ using namespace std;
 namespace ProGe {
 
 RV32MicroCodeGenerator::RV32MicroCodeGenerator(
-    const Machine& machine, const BinaryEncoding& bem)
-    : machine_(&machine),
-      bem_(&bem),
+    const Machine& machine, const BinaryEncoding& bem,
+    const std::string& entityName)
+    : 
+      MicroCodeGenerator(machine, bem, entityName),
       RF_(NULL),
       rs1Bus_(NULL),
       rs2Bus_(NULL),
@@ -1134,7 +1135,7 @@ RV32MicroCodeGenerator::generateMap(const std::string& dstDirectory) {
     stream << "library IEEE;" << std::endl
            << "use IEEE.std_logic_1164.all;" << std::endl
            << "use IEEE.numeric_std.all;" << std::endl
-           << "use work.tta0_globals.all;" << std::endl
+           << "use work." << entityName_ << "_globals.all;" << std::endl
            << std::endl
            << std::endl;
 

--- a/openasip/src/applibs/ProGe/RV32MicroCodeGenerator.hh
+++ b/openasip/src/applibs/ProGe/RV32MicroCodeGenerator.hh
@@ -67,7 +67,8 @@ namespace ProGe {
 class RV32MicroCodeGenerator : public MicroCodeGenerator {
 
 public:
-    RV32MicroCodeGenerator(const Machine& machine, const BinaryEncoding& bem);
+    RV32MicroCodeGenerator(const Machine& machine, const BinaryEncoding& bem,
+    const std::string& entityName);
     ~RV32MicroCodeGenerator();
 
     void generateRTL(HDLTemplateInstantiator& instantiator,
@@ -174,9 +175,6 @@ private:
     void throwOperandCountError(
     const std::string& op, int required, int found) const;
 
-
-    const Machine* machine_;
-    const BinaryEncoding* bem_;
     std::vector<Bus*> busses_;
 
     RegisterFile* RF_;

--- a/testsuite/systemtest_long/procgen/PlatformIntegrator/AlmaIFIntegrator/tcetest_almaif_integrator.sh
+++ b/testsuite/systemtest_long/procgen/PlatformIntegrator/AlmaIFIntegrator/tcetest_almaif_integrator.sh
@@ -79,7 +79,7 @@ function run_test {
     find -name "*.vhd"  -exec ghdl -i --workdir=work {} \; >/dev/null 2>&1
 
     ghdl -i --workdir=work $TB_SRC >/dev/null 2>&1
-    ghdl -m --workdir=work --ieee=synopsys -fexplicit \
+    ghdl -m -Wno-hide --workdir=work --ieee=synopsys -fexplicit \
          --warn-no-unused tta_almaif_tb > compile.log 2>&1
 
     if [ -e tta_almaif_tb ]; then


### PR DESCRIPTION
This PR fixes two issues:
 - It adds "-Wno-hide" switch to ghdl scripts which ignores a harmless warning that is emitted by newer ghdl versions.
 - It adds propagation of the entity name to RISCV hardware that was previously missing.