### PR TITLE
AlmaIF: Fix a bug in almaif_decoder

### DIFF
--- a/openasip/CHANGES
+++ b/openasip/CHANGES
@@ -13,6 +13,7 @@ Notable bugfixes
 ----------------------------
 - ProDe: Fix operand usage and resource boxes to use default colors propagated
   from system theme instead of manually setting them to black and white.
+- AlmaIF: Fix a bug in almaif_decoder memory mask computation
 
 2.0     November 2022
 =====================

--- a/openasip/data/ProGe/platform/almaif_decoder.vhdl
+++ b/openasip/data/ProGe/platform/almaif_decoder.vhdl
@@ -118,7 +118,7 @@ architecture rtl of almaif_decoder is
                 := std_logic_vector(to_unsigned(mem_offset_g/4, axi_addrw_g-2));
   constant mem_mask_c   : std_logic_vector(axi_addrw_g-2-1 downto 0)
                      -- := (mem_addrw_g-2-1 downto 0 => '0', others => '1');
-                        := not std_logic_vector(to_unsigned(2**(mem_addrw_g-2)-1,
+                        := not std_logic_vector(to_unsigned(2**mem_addrw_g-1,
                                                             axi_addrw_g-2));
 
   constant mem_width_log2 : integer := integer(ceil(log2(real(mem_dataw_g))));


### PR DESCRIPTION
There was extra 2 subtracted from on-chip address width when calculating the memory mask to decide whether the memory access is directed to on-chip or to the AXI master. What this caused was that basically only the first quarter of the on-chip memory was actually accessible.

Thankfully this seems to have been fixed by @karihepola in AamuDSP RTL, but didn't seem to get upstreamed back then.