### PR TITLE
Add an installation script for RISC-V tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,35 +169,19 @@ file to your shell with:
 RISC-V
 ------
 If you wish to build OpenASIP with support for RISC-V, you need to install the
-following prerequisites before installing OpenASIP.
+following prerequisites before installing OpenASIP. RISC-V GNU Toolchain
+(https://github.com/riscv-collab/riscv-gnu-toolchain) (version 12.1.0+)
+for common bintools and elf2hex (https://github.com/sifive/elf2hex) for
+generating hex files from RISC-V ELF files.
 
-You need to install the RISC-V GNU Toolchain (version 12.1.0+)
-which brings you the common bintools:
+The easiest way to acquire there tools is to use the included installation
+script:
 
-&nbsp; https://github.com/riscv-collab/riscv-gnu-toolchain
+&nbsp; _tools/scripts/install_riscv_tools.sh $HOME/local_  
 
-Note: If you are using the the RISCV GNU Toolchain with OpenASIP for other
-purposes, the toolchain must be built with the RV32IM target as OpenASIP does
-not currently support the RISC-V C-extension. Thus, you need to configure the
-toolchain build with commands like the following:
+Make sure your installation directory is added to PATH correctly:
 
-&nbsp; _./configure --prefix=/opt/riscv --with-arch=rv32im_ <br>
-&nbsp; _make_
-
-In addition, the elf2hex tool is needed to produce program hex images
-from the ELF files as follows:
-
-&nbsp; _git clone https://github.com/sifive/elf2hex.git <br>
-&nbsp; cd elf2hex <br>
-&nbsp; autoreconf -i <br>
-&nbsp; ./configure --prefix=/opt/riscv --target=riscv32-unknown-elf <br>
-&nbsp; make <br>
-&nbsp; make install_
-
-Add the install bin directory to the $PATH environment. If you installed
-the tools to /opt/riscv, add:
-
-&nbsp; export PATH=/opt/riscv/bin:$PATH
+&nbsp; export PATH=$HOME/local/bin:$PATH <br> 
 
 Building and Installing OpenASIP
 ===========================

--- a/openasip/tools/scripts/install_riscv_tools.sh
+++ b/openasip/tools/scripts/install_riscv_tools.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+TARGET_DIR=${1:?"Missing installation directory argument"}
+ON_PATCH_FAIL="exit 1"
+
+build_dir="riscv-tools-build"
+
+rm -rf $build_dir
+mkdir $build_dir
+cd $build_dir
+
+function eexit {
+   echo "$1"
+   exit 1
+}
+
+function install_gnu_toolchain {
+    version=2023.07.07
+    repository=https://github.com/riscv-collab/riscv-gnu-toolchain
+    name=riscv-gnu-toolchain
+    git clone $repository || eexit "git clone $name failed"
+    cd $name
+    git checkout $version || eexit "git checkout $name $version failed"
+    ./configure --prefix=$TARGET_DIR --with-arch=rv32im \
+        || eexit "configure $name failed"
+    make -j$(nproc) || eexit "make $name failed"
+    cd ..
+}
+
+function install_elf2hex {
+    version=v20.08.00.00
+    repository=https://github.com/sifive/elf2hex.git
+    name=elf2hex
+    git clone $repository || eexit "git clone $name failed"
+    cd $name
+    git checkout $version || eexit "git checkout $name $version failed"
+    ./configure --prefix=$TARGET_DIR --with-arch=rv32im \
+        || eexit "configure $name failed"
+    make || eexit "make $name failed"
+    make install || eexit "make install $name failed"
+    cd ..
+}
+
+install_gnu_toolchain
+install_elf2hex


### PR DESCRIPTION
Adds an installation script for RISC-V prerequisites, which makes it easier for users to acquire them.