### PR TITLE
Backend improvements

### DIFF
--- a/openasip/CHANGES
+++ b/openasip/CHANGES
@@ -10,6 +10,10 @@ Notable changes and features
   Now it's possible to optionally give a list of pairs of
   <address-space-name>,<data-start>.
   - Added the same option to generatebits with the same syntax.
+- Now, backend plugin name is generated from the hash of TDGen output.
+  This allows better reuse of the backend plugins as only machine attributes
+  that are visible to LLVM are inspected.
+- Added an installation script for RISC-V prerequisites
 
 Notable bugfixes
 ----------------------------

--- a/openasip/src/applibs/LLVMBackend/LLVMBackend.cc
+++ b/openasip/src/applibs/LLVMBackend/LLVMBackend.cc
@@ -1101,7 +1101,21 @@ LLVMBackend::createPlugin(const TTAMachine::Machine& target) {
 std::string
 LLVMBackend::pluginFilename(
     const TTAMachine::Machine& target) {
-    TCEString fileName = target.hash();
+    TDGen TDGenerator(target);
+    const std::string buffer = TDGenerator.generateBackend();
+
+    // Generate a hash based on the backend output
+    boost::hash<std::string> string_hasher;
+    size_t h = string_hasher(buffer);
+
+    TCEString hash =
+        (Conversion::toHexString(buffer.length())).substr(2);
+
+    hash += "_";
+    hash += (Conversion::toHexString(h)).substr(2);
+
+    TCEString fileName = hash;
+    // add toolset version to the hash
     fileName += "-" + Application::TCEVersionString();
     fileName += PLUGIN_SUFFIX;
 

--- a/openasip/src/applibs/LLVMBackend/LLVMBackend.cc
+++ b/openasip/src/applibs/LLVMBackend/LLVMBackend.cc
@@ -1123,8 +1123,8 @@ LLVMBackend::pluginFilename() {
     const std::string buffer = pluginGen_->generateBackend();
 
     // Generate a hash based on the backend output
-    boost::hash<std::string> string_hasher;
-    size_t h = string_hasher(buffer);
+    boost::hash<std::string> stringHasher;
+    size_t h = stringHasher(buffer);
 
     TCEString hash =
         (Conversion::toHexString(buffer.length())).substr(2);

--- a/openasip/src/applibs/LLVMBackend/LLVMBackend.hh
+++ b/openasip/src/applibs/LLVMBackend/LLVMBackend.hh
@@ -53,6 +53,7 @@ namespace llvm {
     class TCETargetMachinePlugin;
 }
 
+class TDGen;
 class InterPassData;
 class SchedulingPlan;
 class LLVMTCECmdLineOptions;
@@ -68,25 +69,25 @@ public:
     LLVMBackend(bool useInstalledVersion, TCEString tempDir);
     virtual ~LLVMBackend();
 
+    void setMachine(TTAMachine::Machine& target);
     TTAProgram::Program* compile(
         const std::string& bytecodeFile,
-        const std::string& emulationBytecodeFile, TTAMachine::Machine& target,
+        const std::string& emulationBytecodeFile,
         int optLevel, bool debug = false, InterPassData* ipData = NULL);
 
     TTAProgram::Program* compile(
         llvm::Module& module, llvm::Module* emulationModule,
-        llvm::TCETargetMachinePlugin& plugin, TTAMachine::Machine& target,
+        llvm::TCETargetMachinePlugin& plugin,
         int optLevel, bool debug = false, InterPassData* ipData = NULL);
 
     TTAProgram::Program* schedule(
         const std::string& bytecodeFile,
-        const std::string& emulationBytecodeFile, TTAMachine::Machine& target,
+        const std::string& emulationBytecodeFile,
         int optLevel = 2, bool debug = false, SchedulingPlan* plan = NULL);
 
-    llvm::TCETargetMachinePlugin* createPlugin(
-        const TTAMachine::Machine& target);
+    llvm::TCETargetMachinePlugin* createPlugin();
 
-    std::string pluginFilename(const TTAMachine::Machine& target);
+    std::string pluginFilename();
 
 private:
 
@@ -105,6 +106,8 @@ private:
     LLVMTCECmdLineOptions* options_;
 
     InterPassData* ipData_;
+    TTAMachine::Machine* mach_;
+    TDGen* pluginGen_;
 
     static const std::string TBLGEN_INCLUDES;
     static const std::string PLUGIN_PREFIX;

--- a/openasip/src/applibs/LLVMBackend/TCEStubTargetMachine.cc
+++ b/openasip/src/applibs/LLVMBackend/TCEStubTargetMachine.cc
@@ -150,22 +150,24 @@ TCEStubTargetMachine::TCEStubTargetMachine(
     ST = new TCEStubSubTarget(TT, CPU, FS, *this);
 
     // For autovectorization to work we need to set target machine information:
-    // Load ADF from static adfXML string
+    auto* option = static_cast<llvm::cl::opt<std::string>*>(
+        llvm::cl::getRegisteredOptions().lookup("adf"));
+    const std::string adfName = option->getValue();
+
     ADFSerializer serializer;
-    serializer.setSourceString(adfXML_);
+    if (adfName == "") {
+        const std::string msg = "ADF not passed to opt,"
+                                "make sure it is included in oacc";
+        throw CompileError(__FILE__, __LINE__, __func__, msg);
+    }
+    
+    serializer.setSourceFile(adfName);
     // Create and set TTAMachine
     TTAMachine::Machine* targetTTAMachine = serializer.readMachine();
     setTTAMach(targetTTAMachine);
 }
 
 TCEStubTargetMachine::~TCEStubTargetMachine() {}
-
-void
-TCEStubTargetMachine::setADFString(std::string adfXML) {
-    adfXML_ = adfXML;
-}
-
-std::string TCEStubTargetMachine::adfXML_ = "";
 
 namespace {
     /**

--- a/openasip/src/applibs/LLVMBackend/TCEStubTargetMachine.hh
+++ b/openasip/src/applibs/LLVMBackend/TCEStubTargetMachine.hh
@@ -128,10 +128,6 @@ namespace llvm {
             const override {
             return ST;
         }
-
-        static void setADFString(std::string adfXML);
-
-        static std::string adfXML_;
     };
 } //end namespace llvm
 #endif

--- a/openasip/src/applibs/LLVMBackend/TCETargetMachine.cc
+++ b/openasip/src/applibs/LLVMBackend/TCETargetMachine.cc
@@ -309,8 +309,13 @@ TCEPassConfig::addPreISel() {
  */
 TTAMachine::Machine*
 TCETargetMachine::createMachine() {
+    LLVMTCECmdLineOptions* options =
+        dynamic_cast<LLVMTCECmdLineOptions*>(Application::cmdLineOptions());
+
+    assert(options->isMachineFileDefined() && "ADF not defined");
+    assert(options->machineFile() != "" && "ADF not defined");
     ADFSerializer serializer;
-    serializer.setSourceString(*plugin_->adfXML());
+    serializer.setSourceFile(options->machineFile());
     return serializer.readMachine();
 }
 

--- a/openasip/src/applibs/LLVMBackend/TCETargetMachinePlugin.hh
+++ b/openasip/src/applibs/LLVMBackend/TCETargetMachinePlugin.hh
@@ -155,8 +155,6 @@ namespace llvm {
        virtual int getTruePredicateOpcode(unsigned opc) const = 0;
        virtual int getFalsePredicateOpcode(unsigned opc) const = 0;
 
-       /// Returns pointer to xml string of the target machine .adf
-       virtual const std::string* adfXML() = 0;
        /// Returns name of the data address space.
        virtual std::string dataASName() = 0;
        /// Returns ID number of the return address register.

--- a/openasip/src/applibs/LLVMBackend/TDGen.cc
+++ b/openasip/src/applibs/LLVMBackend/TDGen.cc
@@ -436,6 +436,27 @@ TDGen::generateBackend(std::string& path) {
 }
 
 /**
+ * Writes tce backend plugin code into a single string.
+ * Used for hash generation.
+ */
+std::string
+TDGen::generateBackend() {
+    std::ostringstream buffer; 
+
+    writeRegisterInfo(buffer);
+    writeAddressingModeDefs(buffer);
+    writeOperandDefs(buffer);
+    writeInstrInfo(buffer);
+    writeInstrFormats(buffer);
+    writeCallingConv(buffer);
+    writeArgRegsArray(buffer);
+    writeBackendCode(buffer);
+    writeTopLevelTD(buffer);
+
+    return buffer.str();
+}
+
+/**
  * Writes .td definition of a single register to the output stream.
  *
  * @param o Output stream to write the definition to.
@@ -3990,21 +4011,6 @@ TDGen::writeBackendCode(std::ostream& o) {
         o << "    validStackAccessOperations_.insert(\"" << opName << "\");"
           << std::endl;
     }
-
-    // Target machine .adf XML string.
-    o << std::endl;
-    std::string adfXML;
-    ADFSerializer serializer;
-    serializer.setDestinationString(adfXML);
-    serializer.writeMachine(mach_);
-    o << "    adfXML_ = \"";
-    for (unsigned int i = 0; i < adfXML.length(); i++) {
-        if (adfXML[i] == '"') o << "\\\"";
-        else if (adfXML[i] == '\n') o << "\"\n\"";
-        else o << adfXML[i];
-    }
-    o << "\";" << std::endl;
-
 
     // data address space
     const TTAMachine::Machine::FunctionUnitNavigator& nav =

--- a/openasip/src/applibs/LLVMBackend/TDGen.hh
+++ b/openasip/src/applibs/LLVMBackend/TDGen.hh
@@ -78,7 +78,8 @@ class TDGen {
 public:
     TDGen(const TTAMachine::Machine& mach);
     virtual ~TDGen();
-    void generateBackend(std::string& path);
+    void generateBackend(const std::string& path) const;
+    std::string generateBackend() const;
     // todo clear out virtual functions. they are a remaind of removed
     // TDGenSIMD.
 protected:
@@ -456,10 +457,20 @@ protected:
     TCEString getMovePattern(
         const char& opdType, const std::string& inputPattern) const;
 
+    void initializeBackendContents();
     const TTAMachine::Machine& mach_;
 
     // Current dwarf register number.
     unsigned dregNum_;
+    std::string registerInfo_;
+    std::string addressingModeDefs_;
+    std::string operandDefs_;
+    std::string instrInfo_;
+    std::string instrFormats_;
+    std::string callingConv_;
+    std::string argRegsArray_;
+    std::string backendCode_;
+    std::string topLevelTD_;
 
     /// Float type subword width.
     static const int FP_SUBW_WIDTH;

--- a/openasip/src/applibs/LLVMBackend/plugin/TCETargetMachinePlugin.cc
+++ b/openasip/src/applibs/LLVMBackend/plugin/TCETargetMachinePlugin.cc
@@ -87,10 +87,6 @@ public:
 
     virtual std::vector<unsigned> getVectorRVDRegNums() const override;
 
-    virtual const std::string* adfXML() override {
-        return &adfXML_;
-    }
-
     virtual MVT::SimpleValueType getDefaultType() const override {
 #ifdef TARGET64BIT
         return MVT::i64;
@@ -199,7 +195,6 @@ private:
     /// Set of valid LLVM opcodes for stack accesses.
     TCETools::CIStringSet validStackAccessOperations_;
 
-    std::string adfXML_;
     std::string dataASName_;
 };
 }
@@ -215,9 +210,6 @@ public:
 
         GeneratedTCEPlugin* plugin = new GeneratedTCEPlugin();
         plugin->manualInitialize();
-
-        // Pass adf xml string to the middle-end stub targetmachine
-        TCEStubTargetMachine::setADFString(*(plugin->adfXML()));
 
         // Register LLVM Target and TCE Stub TargetMachine
         LLVMInitializeTCETargetInfo();

--- a/openasip/src/bintools/Compiler/llvm-tce/LLVMTCE.cc
+++ b/openasip/src/bintools/Compiler/llvm-tce/LLVMTCE.cc
@@ -191,9 +191,10 @@ main(int argc, char* argv[]) {
             argc, argv_array.data(), "llvm flags\n");
 
         LLVMBackend compiler(useInstalledVersion, options->tempDir());
+        compiler.setMachine(*mach);
         TTAProgram::Program* seqProg =
             compiler.compile(
-                bytecodeFile, emulationCode, *mach, optLevel, debug, ipData);
+                bytecodeFile, emulationCode, optLevel, debug, ipData);
 
         TTAProgram::Program::writeToTPEF(*seqProg, outputFileName);
         delete seqProg;

--- a/openasip/src/bintools/Compiler/oacc.in
+++ b/openasip/src/bintools/Compiler/oacc.in
@@ -1524,7 +1524,7 @@ if runningInstalled:
     tceOclBitcodeLibDir = os.path.join(tceprefix, "lib/llvmopencl")
     sourceLibSearchPaths = [os.path.join(tceprefix, "share/openasip/srclibs/"),]
     dataDir = os.path.join(tceprefix, "share/openasip/data/tcecc")
-    tceLibpath = os.path.join(tceprefix,"lib/openasip/libopenasip.so")
+    tceLibpath = os.path.join(tceprefix,"lib/libopenasip.so")
 
     # All bclibs should be in the same newlib_libdir.
     # The source libs are located in separate dirs which
@@ -1594,7 +1594,7 @@ if options.autovectorize and options.adf_file != "":
                 backendPluginPath = \
                     "%s/%s" % (options.plugin_cache_dir, line.split()[-1])
                 extraOptSwitches = \
-                    " -load %s -load %s" % (tceLibpath, backendPluginPath)
+                    " -load %s -load %s --adf %s" % (tceLibpath, backendPluginPath, options.adf_file)
     else:
         exitWithError(1, "Error generating TCE LLVM Backend plugin.")
 


### PR DESCRIPTION
LLVM Backend changes:
-  Generate plugin name from TDGen output hash to allow better reuse of compiler backends between machines. Before it was done based on the machine (ADF) hash that would change, for example, if the IC was modified. Now, only attributes that are visible to LLVM are inspected for the plugin.
- Small refactoring to LLVMBackend and TDGen to support these changes.
- Pass adf path to opt instead of constructing a machine model from the backend plugin's ADF XML parameter.